### PR TITLE
Use yaml in favour of js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "xxl": "xxl --src src --exclude /coverage/"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
     "mustache": "^4.0.1",
     "papaparse": "^5.3.2",
-    "timm": "^1.6.2"
+    "timm": "^1.6.2",
+    "yaml": "^2.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import Mustache from "mustache";
 import type { OpeningAndClosingTags } from "mustache";
 import Papa from "papaparse";
 import { readFileSync } from "node:fs";
-import yamlParser from "js-yaml";
+import YAML from 'yaml';
 
 const TEMPLATE_TAGS: OpeningAndClosingTags = ["<<", ">>"];
 const CSV_PARSE_OPTIONS = {
@@ -197,7 +197,7 @@ const _yaml = (tree: Tree, ctx: Context) => {
   }
 
   yaml = yaml.trim();
-  const parsed = yamlParser.load(yaml);
+  const parsed = YAML.parse(yaml);
   return _process(parsed, ctx);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3083,6 +3083,11 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
+yaml@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.1.tgz#42f2b1ba89203f374609572d5349fb8686500773"
+  integrity sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"


### PR DESCRIPTION
This PR deprecates the unmaintained js-yaml library in favour of the up to date yaml library. js-yaml has not had a functional release in 4 years and suffers from a handful of vulnerabilities.