### PR TITLE
Add postbuild.js to rename cjs outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@isardsat/tri",
   "version": "1.13.0",
-  "author": "Lobelia",
-  "license": "MIT",
   "description": "Powerful configuration file processor",
   "keywords": [
     "configuration",
@@ -17,26 +15,31 @@
     "type": "git",
     "url": "https://github.com/lobelia-earth/tri.git"
   },
+  "license": "MIT",
+  "author": "Lobelia",
   "type": "module",
   "exports": {
     ".": {
-      "import": "./lib/index.js",
+      "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/esm/index.d.ts"
     }
   },
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/esm/index.d.ts",
   "files": [
     "lib"
   ],
   "scripts": {
     "build": "tsc && tsc -p tsconfig.cjs.json",
+    "postbuild": "node scripts/postbuild.js",
     "build:watch": "tsc --watch & tsc --watch -p tsconfig.cjs.json",
     "clean": "rm -r lib",
+    "coverage": "vitest run --coverage",
     "lint": "eslint",
     "prettier": "prettier --write .",
     "test": "vitest run",
-    "coverage": "vitest run --coverage",
     "typecheck": "tsc --pretty --noEmit",
     "xxl": "xxl --src src --exclude /coverage/"
   },

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,16 +1,9 @@
 //@ts-check
 
-import { readdirSync, renameSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const dir = join(import.meta.dirname, "../lib/cjs");
-const files = readdirSync(join(import.meta.dirname, "../lib/cjs"));
 
-for (const file of files) {
-  if (file.endsWith(".js")) {
-    const oldPath = join(dir, file);
-    const newPath = join(dir, file.replace(".js", ".cjs"));
-
-    renameSync(oldPath, newPath);
-  }
-}
+const content = JSON.stringify({ type: "commonjs" });
+writeFileSync(join(dir, "package.json"), content);

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,16 @@
+//@ts-check
+
+import { readdirSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = join(import.meta.dirname, "../lib/cjs");
+const files = readdirSync(join(import.meta.dirname, "../lib/cjs"));
+
+for (const file of files) {
+  if (file.endsWith(".js")) {
+    const oldPath = join(dir, file);
+    const newPath = join(dir, file.replace(".js", ".cjs"));
+
+    renameSync(oldPath, newPath);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     // Default to outputting ESM
     "module": "ESNext",
-    "outDir": "lib",
+    "outDir": "lib/esm",
     "declaration": true,
 
     "esModuleInterop": true,


### PR DESCRIPTION
As discussed with Guille, CJS output with a type: module in the root package.json needs a workaround. Either adding a package.json with type: commonjs into the subdirectory or renaming the CJS file to have the .cjs extension. ~~Here I opt for the latter, however the only issue is the watch mode does not work as indended anymore, not sure if there is a clean way of ensuring the script runs on every TSC change.~~ We use a postbuild script to add a package.json file to the CJS directory and fix the importing issue.